### PR TITLE
feat: design a demo icon for 拼图大师

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/puzzle-master-icon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>拼图大师-SLA</title>
   </head>

--- a/public/puzzle-master-icon.svg
+++ b/public/puzzle-master-icon.svg
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="256" height="256" shape-rendering="crispEdges" role="img" aria-labelledby="title desc">
+  <title id="title">拼图大师 Pixel Icon</title>
+  <desc id="desc">A simple flat pixel-style puzzle piece icon for 拼图大师</desc>
+
+  <!-- Gradients -->
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#FF7AD9"/>
+      <stop offset="100%" stop-color="#C07BFF"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background with soft pink-violet gradient -->
+  <rect x="2" y="2" width="60" height="60" rx="12" fill="url(#bg)"/>
+
+  <!-- Pixelated jigsaw piece on a 4px grid, slightly tilted -->
+  <g transform="rotate(-8 32 32)">
+    <!-- Piece shadow for readability -->
+    <path fill="#000000" fill-opacity="0.08" transform="translate(1,1)" d="
+      M 24 20
+      H 28
+      V 12
+      H 36
+      V 20
+      H 44
+      V 28
+      H 40
+      V 36
+      H 44
+      V 44
+      H 36
+      V 52
+      H 28
+      V 44
+      H 20
+      V 36
+      H 24
+      V 28
+      H 16
+      V 20
+      H 24
+      Z"/>
+
+    <!-- Main piece -->
+    <path fill="#FFFFFF" d="
+      M 24 20
+      H 28
+      V 12
+      H 36
+      V 20
+      H 44
+      V 28
+      H 40
+      V 36
+      H 44
+      V 44
+      H 36
+      V 52
+      H 28
+      V 44
+      H 20
+      V 36
+      H 24
+      V 28
+      H 16
+      V 20
+      H 24
+      Z"/>
+  </g>
+
+  <!-- Border accent matching gradient hue -->
+  <rect x="2" y="2" width="60" height="60" rx="12" fill="none" stroke="#A66BEE" stroke-width="2"/>
+</svg>


### PR DESCRIPTION
Replace dafault vite.svg with a **jigsaw-shaped icon file** designed by Codex.

Hope could be merged :-)

![puzzle-master-icon](https://github.com/user-attachments/assets/f1af2a9c-c0a4-4c9d-a75e-fc152de8d598)
